### PR TITLE
Allow loading router_name from openwrt hostname

### DIFF
--- a/etc/config/ip6neigh
+++ b/etc/config/ip6neigh
@@ -20,7 +20,8 @@ config ip6neigh 'config'
 	
 	# Name to be given to the router's IPv6 addresses. Corresponding labels will
 	# be appended for each scope of address. Use '0' if you want to disable this
-	# feature. Default: 'Router'
+	# feature. Will load the option router_name from /etc/config/system if not
+	# specified here. Default: 'Router'
 	#option router_name	'0'
 	
 	# Enable Duplicate Address Detection (DAD) snooping feature. Requires package

--- a/main/ip6neigh-svc.sh
+++ b/main/ip6neigh-svc.sh
@@ -70,7 +70,7 @@ config_load ip6neigh
 config_get LAN_IFACE config lan_iface lan
 config_get WAN_IFACE config wan_iface wan6
 config_get DOMAIN config domain
-config_get ROUTER_NAME config router_name Router
+config_get ROUTER_NAME config router_name
 config_get LLA_LABEL config lla_label
 config_get ULA_LABEL config ula_label
 config_get WULA_LABEL config wula_label
@@ -108,6 +108,12 @@ if [ -z "$DOMAIN" ]; then
 	DOMAIN=$(uci get dhcp.@dnsmasq[0].domain 2>/dev/null)
 fi
 if [ -z "$DOMAIN" ]; then DOMAIN="lan"; fi
+
+#Gets router hostname from /etc/config/system if not defined in ip6neigh config. Defaults to 'Router'.
+if [ -z "$ROUTER_NAME" ]; then
+	ROUTER_NAME=$(uci get system.@system[0].hostname 2>/dev/null)
+fi
+if [ -z "$ROUTER_NAME" ]; then ROUTER_NAME="Router"; fi
 
 #Asks dnsmasq to reload the hosts file if the pending flag is set
 reload_hosts() {
@@ -985,7 +991,7 @@ main_service() {
 	echo "#Predefined SLAAC addresses" >> "$HOSTS_FILE"
 
 	#Adds the router names
-	if [ -n "$ROUTER_NAME" ] && [ "$ROUTER_NAME" != "0" ]; then
+	if [ "$ROUTER_NAME" != "0" ]; then
 		logmsg "Generating names for the router's addresses"
 		[ -n "$lla_address" ] && add_static "$ROUTER_NAME" "$lla_address" "" 0
 		[ -n "$ula_address" ] && add_static "$ROUTER_NAME" "$ula_address" "" 1

--- a/main/ip6neigh-svc.sh
+++ b/main/ip6neigh-svc.sh
@@ -70,7 +70,7 @@ config_load ip6neigh
 config_get LAN_IFACE config lan_iface lan
 config_get WAN_IFACE config wan_iface wan6
 config_get DOMAIN config domain
-config_get ROUTER_NAME config router_name Router
+config_get ROUTER_NAME config router_name
 config_get LLA_LABEL config lla_label
 config_get ULA_LABEL config ula_label
 config_get WULA_LABEL config wula_label
@@ -108,6 +108,12 @@ if [ -z "$DOMAIN" ]; then
 	DOMAIN=$(uci get dhcp.@dnsmasq[0].domain 2>/dev/null)
 fi
 if [ -z "$DOMAIN" ]; then DOMAIN="lan"; fi
+
+#Gets router hostname from /etc/config/system if not defined in ip6neigh config. Defaults to 'Router'.
+if [ -z "$ROUTER_NAME" ]; then
+	ROUTER_NAME=$(uci get system.@system[0].hostname 2>/dev/null)
+fi
+if [ -z "$ROUTER_NAME" ]; then ROUTER_NAME="Router"; fi
 
 #Asks dnsmasq to reload the hosts file if the pending flag is set
 reload_hosts() {
@@ -987,7 +993,7 @@ main_service() {
 	echo "#Predefined SLAAC addresses" >> "$HOSTS_FILE"
 
 	#Adds the router names
-	if [ -n "$ROUTER_NAME" ] && [ "$ROUTER_NAME" != "0" ]; then
+	if [ "$ROUTER_NAME" != "0" ]; then
 		logmsg "Generating names for the router's addresses"
 		[ -n "$lla_address" ] && add_static "$ROUTER_NAME" "$lla_address" "" 0
 		[ -n "$ula_address" ] && add_static "$ROUTER_NAME" "$ula_address" "" 1


### PR DESCRIPTION
Loads router_name from hostname set on /etc/config/system
If no hostname is set, defaults to Router
Can still set 0 to disable this option